### PR TITLE
fix: nested optionals now combine the ref with type null in anyOf

### DIFF
--- a/src/apispec/ext/marshmallow/field_converter.py
+++ b/src/apispec/ext/marshmallow/field_converter.py
@@ -439,7 +439,16 @@ class FieldConverterMixin:
         ):
             schema_dict = self.resolve_nested_schema(field.schema)  # type:ignore
             if ret and "$ref" in schema_dict:
-                ret.update({"allOf": [schema_dict]})
+                if "type" in ret:
+                    type = ret.pop("type")
+                    if isinstance(type, list):
+                        types = list(map(lambda t: {"type": t}, type))
+                    else:
+                        types = [{"type": type}]
+                    types.append(schema_dict)
+                    ret.update({"anyOf": types})
+                else:
+                    ret.update({"allOf": [schema_dict]})
             else:
                 ret.update(schema_dict)
         return ret

--- a/src/apispec/ext/marshmallow/field_converter.py
+++ b/src/apispec/ext/marshmallow/field_converter.py
@@ -442,7 +442,7 @@ class FieldConverterMixin:
                 if "type" in ret:
                     type = ret.pop("type")
                     if isinstance(type, list):
-                        types = list(map(lambda t: {"type": t}, type))
+                        types = [{"type": t} for t in type]
                     else:
                         types = [{"type": type}]
                     types.append(schema_dict)


### PR DESCRIPTION
Proposed fix for https://github.com/marshmallow-code/apispec/issues/833

Note that I tried to do what was described by a contributor https://github.com/marshmallow-code/apispec/issues/833#issuecomment-1494552232 but when the nullable handling is moved to after nested and pluck handling, the context seems to be different - `ret` looks like `{ '$ref': '#/some/type' }` rather than `{ 'allOf': { '$ref': '#/some/type' }, ...}`

Addressing this at the nested handling seemed more self-contained